### PR TITLE
GEN-1393: Bug fix for GravityClient initialization error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "macrocosmos"
-version = "1.0.3"
+version = "1.0.4"
 description = "The official Python SDK for Macrocosmos"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/macrocosmos/client.py
+++ b/src/macrocosmos/client.py
@@ -148,7 +148,7 @@ class AsyncGravityClient(BaseClient):
         self.gravity = AsyncGravity(self)
 
 
-class GravityClient:
+class GravityClient(BaseClient):
     """
     Synchronous client for the Gravity (subnet 13) API on Bittensor.
     """

--- a/uv.lock
+++ b/uv.lock
@@ -556,7 +556,7 @@ wheels = [
 
 [[package]]
 name = "macrocosmos"
-version = "1.0.3"
+version = "1.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio", version = "1.70.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
### Description
#### Issue
 `GravityClient` was not initializing, example `client = mc.GravityClient(api_key=my_key)`
#### Fix 
`GravityClient` now inherits from `BaseClient` and can be initialized. 