### PR TITLE
Update sn13.py

### DIFF
--- a/src/macrocosmos/resources/sn13.py
+++ b/src/macrocosmos/resources/sn13.py
@@ -126,8 +126,8 @@ class SyncSn13:
     def OnDemandData(
         self,
         source: str,
-        usernames: List[str],
-        keywords: List[str],
+        usernames: Optional[List[str]]=[],
+        keywords: Optional[List[str]]=[],
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
         limit: int = 5,


### PR DESCRIPTION
Update Optional parameters for SN13 API.

It will allow people to call the keyword/username search without specifying keywords=[] or usernames=[], which is make usage much more user-friendly.