### PR TITLE
GEN-2014: Add keyword_mode parameter to OnDemandData requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ print(polled_response)
 SN13 is focused on large-scale data collection. With the OnDemandAPI, you can run precise, real-time queries against platforms like X (Twitter) and Reddit (YouTube forthcoming).
 
 As of the latest data-universe [release](https://github.com/macrocosm-os/data-universe/releases/):
-- User's may select two post-filtering modes via the `keyword_mode` parameter: 
+- Users may select two post-filtering modes via the `keyword_mode` parameter: 
     - `"any"`: Returns posts that contain any combination of the listed keywords.
     - `"all"`: Returns posts that contain all of the keywords (default).
 - For Reddit requests, the first keyword in the list corresponds to the requested subreddit, and subsequent keywords are treated as normal.

--- a/README.md
+++ b/README.md
@@ -85,8 +85,10 @@ print(polled_response)
 
 SN13 is focused on large-scale data collection. With the OnDemandAPI, you can run precise, real-time queries against platforms like X (Twitter) and Reddit (YouTube forthcoming).
 
-As of data-universe release [v1.9.8](https://github.com/macrocosm-os/data-universe/releases/tag/v1.9.8):
-- All keywords in the OnDemandData request will be present in the returned post/comment data.
+As of the latest data-universe [release](https://github.com/macrocosm-os/data-universe/releases/):
+- User's may select two post-filtering modes via the `keyword_mode` parameter: 
+    - `"any"`: Returns posts that contain any combination of the listed keywords.
+    - `"all"`: Returns posts that contain all of the keywords (default).
 - For Reddit requests, the first keyword in the list corresponds to the requested subreddit, and subsequent keywords are treated as normal.
 - For YouTube requests, only one username should be supplied - corresponding to the channel name - while keywords are ignored (empty list).
 
@@ -105,7 +107,8 @@ response = client.sn13.OnDemandData(
     keywords=["galaxy"],        # Optional, up to 5 keywords
     start_date='2025-04-15',    # Defaults to 24h range if not specified
     end_date='2025-05-15',      # Defaults to current time if not specified
-    limit=1000                  # Optional, up to 1000 results
+    limit=1000,                 # Optional, up to 1000 results
+    keyword_mode='any'          # Optional, "any" or "all"
 )
 
 print(response)

--- a/examples/sn13_on_demand_data.py
+++ b/examples/sn13_on_demand_data.py
@@ -1,8 +1,10 @@
 """
 Example of using the SN13 On Demand Data Streaming service with Macrocosmos SDK.
 
-As of data-universe release v1.9.8:
-    - All keywords in the OnDemandData request will be present in the returned post/comment data.
+As of the latest data-universe release:
+    - User's may select two post-filtering modes via the keyword_mode parameter:
+        - "any": Returns posts that contain any combination of the listed keywords.
+        - "all": Returns posts that contain all of the keywords (default, if field omitted).
     - For Reddit requests, the first keyword in the list corresponds to the requested subreddit, and subsequent keywords are treated as normal.
     - For YouTube requests, only one username should be supplied - corresponding to the channel name - while keywords are ignored (empty list).
 """

--- a/examples/sn13_on_demand_data.py
+++ b/examples/sn13_on_demand_data.py
@@ -24,7 +24,7 @@ response = client.sn13.OnDemandData(
     start_date="2024-04-01",
     end_date="2025-04-25",
     limit=5,
-    keyword_mode="any"
-    )
+    keyword_mode="any",
+)
 
 print(response)

--- a/examples/sn13_on_demand_data.py
+++ b/examples/sn13_on_demand_data.py
@@ -13,7 +13,7 @@ import macrocosmos as mc
 
 api_key = os.environ.get("SN13_API_KEY", os.environ.get("MACROCOSMOS_API_KEY"))
 
-client = mc.Sn13Client(api_key=api_key, app_name="examples/sn13_on_demand_data.py")
+client = mc.Sn13Client(api_key=api_key, app_name="examples/sn13_on_demand_data.py", base_url="localhost:4000", secure=False)
 
 response = client.sn13.OnDemandData(
     source="x",
@@ -21,7 +21,7 @@ response = client.sn13.OnDemandData(
     keywords=["photo", "space", "mars"],
     start_date="2024-04-01",
     end_date="2025-04-25",
-    limit=3,
-)
+    limit=5
+    )
 
 print(response)

--- a/examples/sn13_on_demand_data.py
+++ b/examples/sn13_on_demand_data.py
@@ -13,7 +13,7 @@ import macrocosmos as mc
 
 api_key = os.environ.get("SN13_API_KEY", os.environ.get("MACROCOSMOS_API_KEY"))
 
-client = mc.Sn13Client(api_key=api_key, app_name="examples/sn13_on_demand_data.py", base_url="localhost:4000", secure=False)
+client = mc.Sn13Client(api_key=api_key, app_name="examples/sn13_on_demand_data.py")
 
 response = client.sn13.OnDemandData(
     source="x",

--- a/examples/sn13_on_demand_data.py
+++ b/examples/sn13_on_demand_data.py
@@ -23,7 +23,8 @@ response = client.sn13.OnDemandData(
     keywords=["photo", "space", "mars"],
     start_date="2024-04-01",
     end_date="2025-04-25",
-    limit=5
+    limit=5,
+    keyword_mode="any"
     )
 
 print(response)

--- a/examples/sn13_on_demand_data.py
+++ b/examples/sn13_on_demand_data.py
@@ -2,7 +2,7 @@
 Example of using the SN13 On Demand Data Streaming service with Macrocosmos SDK.
 
 As of the latest data-universe release:
-    - User's may select two post-filtering modes via the keyword_mode parameter:
+    - Users may select two post-filtering modes via the keyword_mode parameter:
         - "any": Returns posts that contain any combination of the listed keywords.
         - "all": Returns posts that contain all of the keywords (default, if field omitted).
     - For Reddit requests, the first keyword in the list corresponds to the requested subreddit, and subsequent keywords are treated as normal.

--- a/examples/sn13_on_demand_data_async.py
+++ b/examples/sn13_on_demand_data_async.py
@@ -53,9 +53,7 @@ async def main():
     # Create async sn13 client
     client = mc.AsyncSn13Client(
         api_key=api_key, 
-        app_name="examples/sn13_on_demand_data_async.py",
-        base_url="localhost:4000",
-        secure=False,
+        app_name="examples/sn13_on_demand_data_async.py"
     )
 
     # Define multiple concurrent requests with different parameters

--- a/examples/sn13_on_demand_data_async.py
+++ b/examples/sn13_on_demand_data_async.py
@@ -3,7 +3,7 @@ Example demonstrating concurrent async operations with the SN13 On Demand Data s
 Shows how multiple requests can be processed simultaneously in an async context.
 
 As of the latest data-universe release:
-    - User's may select two post-filtering modes via the keyword_mode parameter:
+    - Users may select two post-filtering modes via the keyword_mode parameter:
         - "any": Returns posts that contain any combination of the listed keywords.
         - "all": Returns posts that contain all of the keywords (default, if field omitted).
     - For Reddit requests, the first keyword in the list corresponds to the requested subreddit, and subsequent keywords are treated as normal.

--- a/examples/sn13_on_demand_data_async.py
+++ b/examples/sn13_on_demand_data_async.py
@@ -76,11 +76,12 @@ async def main():
         {
             "source": "reddit",
             "usernames": [],
-            "keywords": ["r/CasualUK", 
-                         "moon",
-                         "tonight",
-                         "nice"
-            ],  # First keyword is the subreddit, next keywords should bother appear in returned posts
+            "keywords": [
+                "r/CasualUK", 
+                "moon",
+                "tonight",
+                "nice"
+            ],  # First keyword is the subreddit, next keywords should all appear in returned posts
             "start_date": "2025-09-01",
             "end_date": "2025-09-08",
             "limit": 5,
@@ -94,7 +95,7 @@ async def main():
             "start_date": "2025-07-01",
             "end_date": "2025-09-06",
             "limit": 1,
-            "request_id": 4,
+            "request_id": 3,
         },
     ]
 

--- a/examples/sn13_on_demand_data_async.py
+++ b/examples/sn13_on_demand_data_async.py
@@ -2,8 +2,10 @@
 Example demonstrating concurrent async operations with the SN13 On Demand Data service.
 Shows how multiple requests can be processed simultaneously in an async context.
 
-As of data-universe release v1.9.8:
-    - All keywords in the OnDemandData request will be present in the returned post/comment data.
+As of the latest data-universe release:
+    - User's may select two post-filtering modes via the keyword_mode parameter:
+        - "any": Returns posts that contain any combination of the listed keywords.
+        - "all": Returns posts that contain all of the keywords (default, if field omitted).
     - For Reddit requests, the first keyword in the list corresponds to the requested subreddit, and subsequent keywords are treated as normal.
     - For YouTube requests, only one username should be supplied - corresponding to the channel name - while keywords are ignored (empty list).
 """

--- a/examples/sn13_on_demand_data_async.py
+++ b/examples/sn13_on_demand_data_async.py
@@ -11,6 +11,7 @@ As of data-universe release v1.9.8:
 import os
 import asyncio
 import time
+from typing import Optional
 
 import macrocosmos as mc
 
@@ -24,6 +25,7 @@ async def fetch_data(
     end_date: str,
     limit: int,
     request_id: int,
+    keyword_mode: Optional[str] = None,
 ):
     """Fetch data for a single request and track its timing."""
     start_time = time.time()
@@ -36,6 +38,7 @@ async def fetch_data(
         start_date=start_date,
         end_date=end_date,
         limit=limit,
+        keyword_mode=keyword_mode,
     )
 
     end_time = time.time()
@@ -49,7 +52,10 @@ async def main():
 
     # Create async sn13 client
     client = mc.AsyncSn13Client(
-        api_key=api_key, app_name="examples/sn13_on_demand_data_async.py"
+        api_key=api_key, 
+        app_name="examples/sn13_on_demand_data_async.py",
+        base_url="localhost:4000",
+        secure=False,
     )
 
     # Define multiple concurrent requests with different parameters
@@ -60,29 +66,35 @@ async def main():
             "keywords": [
                 "photo",
                 "space",
-            ],  # Posts including both keywords will be returned
+            ],  # Posts including either keyword will be returned
             "start_date": "2024-04-01",
             "end_date": "2024-04-30",
             "limit": 5,
             "request_id": 1,
+            "keyword_mode": "any",
         },
         {
             "source": "reddit",
-            "usernames": ["TheMuseumOfScience"],
-            "keywords": ["r/nasa", "vision"],  # First keyword is the subreddit
-            "start_date": "2025-04-01",
-            "end_date": "2025-08-25",
-            "limit": 1,
+            "usernames": [],
+            "keywords": ["r/CasualUK", 
+                         "moon",
+                         "tonight",
+                         "nice"
+            ],  # First keyword is the subreddit, next keywords should bother appear in returned posts
+            "start_date": "2025-09-01",
+            "end_date": "2025-09-08",
+            "limit": 5,
             "request_id": 2,
+            "keyword_mode": "all",
         },
         {
             "source": "youtube",
             "usernames": ["veritasium"],
             "keywords": [],  # YouTube does not currently support keywords, list left empty
-            "start_date": "2025-08-01",
-            "end_date": "2025-08-06",
+            "start_date": "2025-07-01",
+            "end_date": "2025-09-06",
             "limit": 1,
-            "request_id": 3,
+            "request_id": 4,
         },
     ]
 

--- a/examples/sn13_on_demand_data_async.py
+++ b/examples/sn13_on_demand_data_async.py
@@ -54,8 +54,7 @@ async def main():
 
     # Create async sn13 client
     client = mc.AsyncSn13Client(
-        api_key=api_key, 
-        app_name="examples/sn13_on_demand_data_async.py"
+        api_key=api_key, app_name="examples/sn13_on_demand_data_async.py"
     )
 
     # Define multiple concurrent requests with different parameters
@@ -77,10 +76,10 @@ async def main():
             "source": "reddit",
             "usernames": [],
             "keywords": [
-                "r/CasualUK", 
+                "r/CasualUK",
                 "moon",
                 "tonight",
-                "nice"
+                "nice",
             ],  # First keyword is the subreddit, next keywords should all appear in returned posts
             "start_date": "2025-09-01",
             "end_date": "2025-09-08",

--- a/protos/apex/v1/apex.proto
+++ b/protos/apex/v1/apex.proto
@@ -25,10 +25,13 @@ service ApexService {
   rpc GetDeepResearcherJob(GetDeepResearcherJobRequest) returns (GetDeepResearcherJobResponse);
 
   // GetChatSessions retrieves a user's chats
-  rpc GetChatSessions(google.protobuf.Empty) returns (GetChatSessionsResponse);
+  rpc GetChatSessions(GetChatSessionsRequest) returns (GetChatSessionsResponse);
 
   // GetStoredChatCompletions retrieves a chat's completions
   rpc GetStoredChatCompletions(GetStoredChatCompletionsRequest) returns (GetStoredChatCompletionsResponse);
+
+  // GetChatCompletion retrieves a completion by its ID
+  rpc GetChatCompletion(GetChatCompletionRequest) returns (StoredChatCompletion);
 
   // UpdateChatAttributes updates specified attributes of a chat
   rpc UpdateChatAttributes(UpdateChatAttributesRequest) returns (UpdateChatAttributesResponse);
@@ -461,10 +464,22 @@ message GetChatSessionsResponse {
   repeated ChatSession chat_sessions = 1;
 }
 
+// A GetChatSessionsRequest message
+message GetChatSessionsRequest {
+  // chat_type: type of chat (e.g. "apex" or "gravity")
+  string chat_type = 1;
+}
+
 // A GetStoredChatCompletionRequest request message
 message GetStoredChatCompletionsRequest {
   // chat_id: a unique identifier for a chat
   string chat_id = 1;
+}
+
+// A GetChatCompletionRequest request message
+message GetChatCompletionRequest {
+  // completion_id: a unique identifier for a completion
+  string completion_id = 1;
 }
 
 
@@ -620,6 +635,8 @@ message UpdateCompletionAttributesRequest {
   optional string completion_text = 2;
   // metadata: metadata json blob (optional)
   google.protobuf.Struct metadata = 3;
+  // user_prompt_text: the user's prompt text (optional)
+  optional string user_prompt_text = 4;
 }
 
 // An UpdateCompletionAttributes response

--- a/protos/gravity/v1/gravity.proto
+++ b/protos/gravity/v1/gravity.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package gravity.v1;
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/empty.proto";
 
 option go_package = "macrocosm-os/rift/constellation_api/gen/gravity/v1";
 
@@ -14,7 +15,8 @@ service GravityService {
   rpc GetCrawler(GetCrawlerRequest) returns (GetCrawlerResponse);
 
   // Create a new gravity task
-  rpc CreateGravityTask(CreateGravityTaskRequest) returns (CreateGravityTaskResponse);
+  rpc CreateGravityTask(CreateGravityTaskRequest)
+      returns (CreateGravityTaskResponse);
 
   // Build a dataset for a single crawler
   rpc BuildDataset(BuildDatasetRequest) returns (BuildDatasetResponse);
@@ -23,16 +25,58 @@ service GravityService {
   rpc GetDataset(GetDatasetRequest) returns (GetDatasetResponse);
 
   // Cancel a gravity task and any crawlers associated with it
-  rpc CancelGravityTask(CancelGravityTaskRequest) returns (CancelGravityTaskResponse);
+  rpc CancelGravityTask(CancelGravityTaskRequest)
+      returns (CancelGravityTaskResponse);
 
   // Cancel dataset build if it is in progress and purges the dataset
   rpc CancelDataset(CancelDatasetRequest) returns (CancelDatasetResponse);
 
   // Refund user if fewer rows are returned
-  rpc DatasetBillingCorrection(DatasetBillingCorrectionRequest) returns (DatasetBillingCorrectionResponse);
+  rpc DatasetBillingCorrection(DatasetBillingCorrectionRequest)
+      returns (DatasetBillingCorrectionResponse);
+
+  // Gets the available datsets for use in Dataset Marketplace
+  rpc GetMarketplaceDatasets(google.protobuf.Empty)
+      returns (GetMarketplaceDatasetsResponse);
+
+  // Gets all dataset files for a given gravity task
+  rpc GetGravityTaskDatasetFiles(GetGravityTaskDatasetFilesRequest)
+      returns (GetGravityTaskDatasetFilesResponse);
+
+  // Publishes a dataset into the Marketplace
+  rpc PublishDataset(PublishDatasetRequest) returns (UpsertResponse);
+
+  // Upserts a crawler into the Gravity state DB
+  rpc UpsertCrawler(UpsertCrawlerRequest) returns (UpsertResponse);
+
+  // Upserts a crawler criteria into the Gravity state DB
+  rpc InsertCrawlerCriteria(InsertCrawlerCriteriaRequest)
+      returns (UpsertResponse);
+
+  // Upserts a gravity task into the Gravity state DB
+  rpc UpsertGravityTask(UpsertGravityTaskRequest)
+      returns (UpsertGravityTaskResponse);
+  // Upserts a dataset into to the Gravity state DB
+  rpc UpsertDataset(UpsertDatasetRequest) returns (UpsertResponse);
+
+  // Inserts a dataset file row into the Gravity state DB
+  rpc InsertDatasetFile(InsertDatasetFileRequest) returns (UpsertResponse);
+
+  // Upserts a nebula into the Gravity nebula DB
+  rpc UpsertNebula(UpsertNebulaRequest) returns (UpsertResponse);
+
+  // Builds all datasets for a task (additionally cancels crawlers with no data)
+  rpc BuildAllDatasets(BuildAllDatasetsRequest) returns (BuildAllDatasetsResponse);
 }
 
-// Crawler is a single crawler workflow that registers a single job (platform/topic) on SN13's dynamic desirability engine
+// PublishDatasetRequest is the request message for publishing a dataset
+message PublishDatasetRequest {
+  // dataset_id: the ID of the dataset
+  string dataset_id = 1;
+}
+
+// Crawler is a single crawler workflow that registers a single job
+// (platform/topic) on SN13's dynamic desirability engine
 message Crawler {
   // crawler_id: the ID of the crawler
   string crawler_id = 1;
@@ -46,8 +90,62 @@ message Crawler {
   google.protobuf.Timestamp archive_time = 5;
   // state: the current state of the crawler
   CrawlerState state = 6;
-  // dataset_workflows: the IDs of the dataset workflows that are associated with the crawler
+  // dataset_workflows: the IDs of the dataset workflows that are associated
+  // with the crawler
   repeated string dataset_workflows = 7;
+}
+
+// UpsertCrawlerRequest for upserting a crawler and its criteria
+message UpsertCrawlerRequest {
+  // gravity_task_id: the parent workflow id -- in this case the multicrawler id
+  string gravity_task_id = 1;
+  // crawler: the crawler to upsert into the database
+  Crawler crawler = 2;
+}
+
+// UpsertResponse is the response message for upserting a crawler
+message UpsertResponse {
+  // message: the message of upserting a crawler (currently hardcoded to
+  // "success")
+  string message = 1;
+}
+
+// UpsertGravityTaskRequest for upserting a gravity task
+message UpsertGravityTaskRequest {
+  // gravity_task: the gravity task to upsert into the database
+  GravityTaskRequest gravity_task = 1;
+}
+
+// UpsertGravityTaskResponse is the response message for upserting a gravity
+// task
+message UpsertGravityTaskResponse {
+  // message: the message of upserting a gravity task (currently hardcoded to
+  // "success")
+  string message = 1;
+}
+
+// GravityTaskRequest represents the data needed to upsert a gravity task
+message GravityTaskRequest {
+  // id: the ID of the gravity task
+  string id = 1;
+  // name: the name of the gravity task
+  string name = 2;
+  // status: the status of the gravity task
+  string status = 3;
+  // start_time: the start time of the gravity task
+  google.protobuf.Timestamp start_time = 4;
+  // notification_to: the notification email address
+  string notification_to = 5;
+  // notification_link: the notification redirect link
+  string notification_link = 6;
+}
+
+// UpsertCrawlerCriteriaRequest for upserting a crawler and its criteria
+message InsertCrawlerCriteriaRequest {
+  // crawler_id: the id of the crawler
+  string crawler_id = 1;
+  // crawler_criteria: the crawler criteria to upsert into the database
+  CrawlerCriteria crawler_criteria = 2;
 }
 
 // CrawlerCriteria is the contents of the job and the notification details
@@ -117,21 +215,26 @@ message GravityTaskState {
   string status = 3;
   // start_time: the time the gravity task was created
   google.protobuf.Timestamp start_time = 4;
-  // crawler_ids: the IDs of the crawler workflows that are associated with the gravity task
+  // crawler_ids: the IDs of the crawler workflows that are associated with the
+  // gravity task
   repeated string crawler_ids = 5;
-  // crawler_workflows: the crawler workflows that are associated with the gravity task
+  // crawler_workflows: the crawler workflows that are associated with the
+  // gravity task
   repeated Crawler crawler_workflows = 6;
 }
 
-// GetGravityTasksRequest is the request message for listing gravity tasks for a user
+// GetGravityTasksRequest is the request message for listing gravity tasks for a
+// user
 message GetGravityTasksRequest {
-  // gravity_task_id: the ID of the gravity task (optional, if not provided, all gravity tasks for the user will be returned)
+  // gravity_task_id: the ID of the gravity task (optional, if not provided, all
+  // gravity tasks for the user will be returned)
   optional string gravity_task_id = 1;
   // include_crawlers: whether to include the crawler states in the response
   optional bool include_crawlers = 2;
 }
 
-// GetGravityTasksResponse is the response message for listing gravity tasks for a user
+// GetGravityTasksResponse is the response message for listing gravity tasks for
+// a user
 message GetGravityTasksResponse {
   // gravity_task_states: the current states of the gravity tasks
   repeated GravityTaskState gravity_task_states = 1;
@@ -151,13 +254,17 @@ message GravityTask {
   optional google.protobuf.Timestamp post_end_datetime = 5;
 }
 
-// NotificationRequest is the request message for sending a notification to a user when a dataset is ready to download
+// NotificationRequest is the request message for sending a notification to a
+// user when a dataset is ready to download
 message NotificationRequest {
-  // type: the type of notification to send ('email' is only supported currently)
+  // type: the type of notification to send ('email' is only supported
+  // currently)
   string type = 1;
-  // address: the address to send the notification to (only email addresses are supported currently)
+  // address: the address to send the notification to (only email addresses are
+  // supported currently)
   string address = 2;
-  // redirect_url: the URL to include in the notication message that redirects the user to any built datasets
+  // redirect_url: the URL to include in the notication message that redirects
+  // the user to any built datasets
   optional string redirect_url = 3;
 }
 
@@ -173,42 +280,65 @@ message GetCrawlerResponse {
   Crawler crawler = 1;
 }
 
-// CreateGravityTaskRequest is the request message for creating a new gravity task
+// CreateGravityTaskRequest is the request message for creating a new gravity
+// task
 message CreateGravityTaskRequest {
   // gravity_tasks: the criteria for the crawlers that will be created
   repeated GravityTask gravity_tasks = 1;
-  // name: the name of the gravity task (optional, default will generate a random name)
+  // name: the name of the gravity task (optional, default will generate a
+  // random name)
   string name = 2;
-  // notification_requests: the details of the notification to be sent to the user when a dataset
-  //   that is automatically generated upon completion of the crawler is ready to download (optional)
+  // notification_requests: the details of the notification to be sent to the
+  // user when a dataset
+  //   that is automatically generated upon completion of the crawler is ready
+  //   to download (optional)
   repeated NotificationRequest notification_requests = 3;
-  // gravity_task_id: the ID of the gravity task (optional, default will generate a random ID)
+  // gravity_task_id: the ID of the gravity task (optional, default will
+  // generate a random ID)
   optional string gravity_task_id = 4;
 }
 
-// CreateGravityTaskResponse is the response message for creating a new gravity task
+// CreateGravityTaskResponse is the response message for creating a new gravity
+// task
 message CreateGravityTaskResponse {
   // gravity_task_id: the ID of the gravity task
   string gravity_task_id = 1;
 }
 
-// BuildDatasetRequest is the request message for manually requesting the building of a dataset for a single crawler
+// BuildDatasetRequest is the request message for manually requesting the
+// building of a dataset for a single crawler
 message BuildDatasetRequest {
   // crawler_id: the ID of the crawler that will be used to build the dataset
   string crawler_id = 1;
-  // notification_requests: the details of the notification to be sent to the user when the dataset is ready to download (optional)
+  // notification_requests: the details of the notification to be sent to the
+  // user when the dataset is ready to download (optional)
   repeated NotificationRequest notification_requests = 2;
-  // max_rows: the maximum number of rows to include in the dataset (optional, defaults to 500)
+  // max_rows: the maximum number of rows to include in the dataset (optional,
+  // defaults to 500)
   int64 max_rows = 3;
 }
 
-// BuildDatasetResponse is the response message for manually requesting the building of a dataset for a single crawler
+// BuildDatasetResponse is the response message for manually requesting the
+// building of a dataset for a single crawler
 // - dataset: the dataset that was built
 message BuildDatasetResponse {
   // dataset_id: the ID of the dataset
   string dataset_id = 1;
   // dataset: the dataset that was built
   Dataset dataset = 2;
+}
+
+// BuildAllDatasetsRequest is the request message for building all datasets
+// belonging to a workflow
+message BuildAllDatasetsRequest {
+  // gravityTaskId specifies which task to build
+  string gravity_task_id = 1;
+  // specifies how much of each crawler to build for workflow
+  repeated BuildDatasetRequest build_crawlers_config = 2;
+}
+message BuildAllDatasetsResponse {
+  string gravity_task_id = 1;
+  repeated Dataset datasets = 2;
 }
 
 message Nebula {
@@ -240,6 +370,34 @@ message Dataset {
   int64 total_steps = 8;
   // nebula: the details about the nebula that was built
   Nebula nebula = 9;
+}
+
+// UpsertDatasetRequest contains the dataset id to insert and the dataset
+// details
+message UpsertDatasetRequest {
+  // dataset_id: a unique id for the dataset
+  string dataset_id = 1;
+  // dataset: the details of the dataset
+  Dataset dataset = 2;
+}
+
+// UpsertNebulaRequest contains the dataset id and nebula details to upsert
+message UpsertNebulaRequest {
+  // dataset_id: a unique id for the dataset
+  string dataset_id = 1;
+  // nebula_id: a unique id for the nebula
+  string nebula_id = 2;
+  // nebula: the details of the nebula
+  Nebula nebula = 3;
+}
+
+// InsertDatasetFileRequest contains the dataset id to insert into and the
+// dataset file details
+message InsertDatasetFileRequest {
+  // dataset_id: the ID of the dataset to attach the file to
+  string dataset_id = 1;
+  // files: the dataset files to insert
+  repeated DatasetFile files = 2;
 }
 
 // DatasetFile contains the details about a dataset file
@@ -275,7 +433,8 @@ message GetDatasetRequest {
   string dataset_id = 1;
 }
 
-// GetDatasetResponse is the response message for getting the status of a dataset
+// GetDatasetResponse is the response message for getting the status of a
+// dataset
 message GetDatasetResponse {
   // dataset: the dataset that is being built
   Dataset dataset = 1;
@@ -287,9 +446,11 @@ message CancelGravityTaskRequest {
   string gravity_task_id = 1;
 }
 
-// CancelGravityTaskResponse is the response message for cancelling a gravity task
+// CancelGravityTaskResponse is the response message for cancelling a gravity
+// task
 message CancelGravityTaskResponse {
-  // message: the message of the cancellation of the gravity task (currently hardcoded to "success")
+  // message: the message of the cancellation of the gravity task (currently
+  // hardcoded to "success")
   string message = 1;
 }
 
@@ -301,7 +462,8 @@ message CancelDatasetRequest {
 
 // CancelDatasetResponse is the response message for cancelling a dataset build
 message CancelDatasetResponse {
-  // message: the message of the cancellation of the dataset build (currently hardcoded to "success")
+  // message: the message of the cancellation of the dataset build (currently
+  // hardcoded to "success")
   string message = 1;
 }
 
@@ -317,4 +479,53 @@ message DatasetBillingCorrectionRequest {
 message DatasetBillingCorrectionResponse {
   // refund_amount
   double refund_amount = 1;
+}
+
+// GetMarketplaceDatasetsResponse returns the dataset metadata to be used in
+// Marketplace
+message GetMarketplaceDatasetsResponse {
+  // datasets: list of marketplace datasets
+  repeated DatasetFile datasets = 1;
+}
+
+// GetGravityTaskDatasetFilesRequest is the request message for getting dataset
+// files for a gravity task
+message GetGravityTaskDatasetFilesRequest {
+  // gravity_task_id: the ID of the gravity task (required)
+  string gravity_task_id = 1;
+}
+
+// CrawlerDatasetFiles contains dataset files for a specific crawler
+message CrawlerDatasetFiles {
+  // crawler_id: the ID of the crawler
+  string crawler_id = 1;
+  // dataset_files: the dataset files associated with this crawler
+  repeated DatasetFileWithId dataset_files = 2;
+}
+
+// DatasetFileWithId extends DatasetFile to include the dataset ID
+message DatasetFileWithId {
+  // dataset_id: the ID of the dataset this file belongs to
+  string dataset_id = 1;
+  // file_name: the name of the file
+  string file_name = 2;
+  // file_size_bytes: the size of the file in bytes
+  uint64 file_size_bytes = 3;
+  // last_modified: the date the file was last modified
+  google.protobuf.Timestamp last_modified = 4;
+  // num_rows: the number of rows in the file
+  uint64 num_rows = 5;
+  // s3_key: the key of the file in S3 (internal use only)
+  string s3_key = 6;
+  // url: the URL of the file (public use)
+  string url = 7;
+}
+
+// GetGravityTaskDatasetFilesResponse is the response message for getting
+// dataset files for a gravity task
+message GetGravityTaskDatasetFilesResponse {
+  // gravity_task_id: the ID of the gravity task
+  string gravity_task_id = 1;
+  // crawler_dataset_files: dataset files grouped by crawler
+  repeated CrawlerDatasetFiles crawler_dataset_files = 2;
 }

--- a/protos/sn13/v1/sn13_validator.proto
+++ b/protos/sn13/v1/sn13_validator.proto
@@ -71,6 +71,9 @@ message OnDemandDataRequest {
   optional string end_date = 5;
   // limit: maximum number of results to return
   optional int64 limit = 6;
+  // keyword_mode: defines how keywords should be used in selecting response posts (optional): 
+  // "all" (posts must include all keywords) or "any" (posts can include any combination of keywords)
+  optional string keyword_mode = 7;
 }
 
 // OnDemandDataResponse is the response from SN13 for an on-demand data request

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "macrocosmos"
-version = "1.1.3"
+version = "1.1.4"
 description = "The official Python SDK for Macrocosmos"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/macrocosmos/generated/sn13/v1/sn13_validator_p2p.py
+++ b/src/macrocosmos/generated/sn13/v1/sn13_validator_p2p.py
@@ -77,6 +77,9 @@ class OnDemandDataRequest(BaseModel):
     end_date: typing.Optional[str] = Field(default="")
 # limit: maximum number of results to return
     limit: typing.Optional[int] = Field(default=0)
+# keyword_mode: defines how keywords should be used in selecting response posts (optional): 
+# "all" (posts must include all keywords) or "any" (posts can include any combination of keywords)
+    keyword_mode: typing.Optional[str] = Field(default="")
 
 class OnDemandDataResponse(BaseModel):
     """

--- a/src/macrocosmos/generated/sn13/v1/sn13_validator_pb2.py
+++ b/src/macrocosmos/generated/sn13/v1/sn13_validator_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1csn13/v1/sn13_validator.proto\x12\x07sn13.v1\x1a\x1cgoogle/protobuf/struct.proto\"#\n\x11ListTopicsRequest\x12\x0e\n\x06source\x18\x01 \x01(\t\"k\n\x18ListTopicsResponseDetail\x12\x13\n\x0blabel_value\x18\x01 \x01(\t\x12\x1a\n\x12\x63ontent_size_bytes\x18\x02 \x01(\x04\x12\x1e\n\x16\x61\x64j_content_size_bytes\x18\x03 \x01(\x04\"H\n\x12ListTopicsResponse\x12\x32\n\x07\x64\x65tails\x18\x01 \x03(\x0b\x32!.sn13.v1.ListTopicsResponseDetail\"+\n\x1aValidateRedditTopicRequest\x12\r\n\x05topic\x18\x01 \x01(\t\"r\n\x1bValidateRedditTopicResponse\x12\x10\n\x08platform\x18\x01 \x01(\t\x12\r\n\x05topic\x18\x02 \x01(\t\x12\x0e\n\x06\x65xists\x18\x03 \x01(\x08\x12\x0e\n\x06over18\x18\x04 \x01(\x08\x12\x12\n\nquarantine\x18\x05 \x01(\x08\"\xb4\x01\n\x13OnDemandDataRequest\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\x11\n\tusernames\x18\x02 \x03(\t\x12\x10\n\x08keywords\x18\x03 \x03(\t\x12\x17\n\nstart_date\x18\x04 \x01(\tH\x00\x88\x01\x01\x12\x15\n\x08\x65nd_date\x18\x05 \x01(\tH\x01\x88\x01\x01\x12\x12\n\x05limit\x18\x06 \x01(\x03H\x02\x88\x01\x01\x42\r\n\x0b_start_dateB\x0b\n\t_end_dateB\x08\n\x06_limit\"t\n\x14OnDemandDataResponse\x12\x0e\n\x06status\x18\x01 \x01(\t\x12%\n\x04\x64\x61ta\x18\x02 \x03(\x0b\x32\x17.google.protobuf.Struct\x12%\n\x04meta\x18\x03 \x01(\x0b\x32\x17.google.protobuf.Struct2\x83\x02\n\x0bSn13Service\x12\x45\n\nListTopics\x12\x1a.sn13.v1.ListTopicsRequest\x1a\x1b.sn13.v1.ListTopicsResponse\x12`\n\x13ValidateRedditTopic\x12#.sn13.v1.ValidateRedditTopicRequest\x1a$.sn13.v1.ValidateRedditTopicResponse\x12K\n\x0cOnDemandData\x12\x1c.sn13.v1.OnDemandDataRequest\x1a\x1d.sn13.v1.OnDemandDataResponseB1Z/macrocosm-os/rift/constellation_api/gen/sn13/v1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1csn13/v1/sn13_validator.proto\x12\x07sn13.v1\x1a\x1cgoogle/protobuf/struct.proto\"#\n\x11ListTopicsRequest\x12\x0e\n\x06source\x18\x01 \x01(\t\"k\n\x18ListTopicsResponseDetail\x12\x13\n\x0blabel_value\x18\x01 \x01(\t\x12\x1a\n\x12\x63ontent_size_bytes\x18\x02 \x01(\x04\x12\x1e\n\x16\x61\x64j_content_size_bytes\x18\x03 \x01(\x04\"H\n\x12ListTopicsResponse\x12\x32\n\x07\x64\x65tails\x18\x01 \x03(\x0b\x32!.sn13.v1.ListTopicsResponseDetail\"+\n\x1aValidateRedditTopicRequest\x12\r\n\x05topic\x18\x01 \x01(\t\"r\n\x1bValidateRedditTopicResponse\x12\x10\n\x08platform\x18\x01 \x01(\t\x12\r\n\x05topic\x18\x02 \x01(\t\x12\x0e\n\x06\x65xists\x18\x03 \x01(\x08\x12\x0e\n\x06over18\x18\x04 \x01(\x08\x12\x12\n\nquarantine\x18\x05 \x01(\x08\"\xe0\x01\n\x13OnDemandDataRequest\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\x11\n\tusernames\x18\x02 \x03(\t\x12\x10\n\x08keywords\x18\x03 \x03(\t\x12\x17\n\nstart_date\x18\x04 \x01(\tH\x00\x88\x01\x01\x12\x15\n\x08\x65nd_date\x18\x05 \x01(\tH\x01\x88\x01\x01\x12\x12\n\x05limit\x18\x06 \x01(\x03H\x02\x88\x01\x01\x12\x19\n\x0ckeyword_mode\x18\x07 \x01(\tH\x03\x88\x01\x01\x42\r\n\x0b_start_dateB\x0b\n\t_end_dateB\x08\n\x06_limitB\x0f\n\r_keyword_mode\"t\n\x14OnDemandDataResponse\x12\x0e\n\x06status\x18\x01 \x01(\t\x12%\n\x04\x64\x61ta\x18\x02 \x03(\x0b\x32\x17.google.protobuf.Struct\x12%\n\x04meta\x18\x03 \x01(\x0b\x32\x17.google.protobuf.Struct2\x83\x02\n\x0bSn13Service\x12\x45\n\nListTopics\x12\x1a.sn13.v1.ListTopicsRequest\x1a\x1b.sn13.v1.ListTopicsResponse\x12`\n\x13ValidateRedditTopic\x12#.sn13.v1.ValidateRedditTopicRequest\x1a$.sn13.v1.ValidateRedditTopicResponse\x12K\n\x0cOnDemandData\x12\x1c.sn13.v1.OnDemandDataRequest\x1a\x1d.sn13.v1.OnDemandDataResponseB1Z/macrocosm-os/rift/constellation_api/gen/sn13/v1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -44,9 +44,9 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_VALIDATEREDDITTOPICRESPONSE']._serialized_start=336
   _globals['_VALIDATEREDDITTOPICRESPONSE']._serialized_end=450
   _globals['_ONDEMANDDATAREQUEST']._serialized_start=453
-  _globals['_ONDEMANDDATAREQUEST']._serialized_end=633
-  _globals['_ONDEMANDDATARESPONSE']._serialized_start=635
-  _globals['_ONDEMANDDATARESPONSE']._serialized_end=751
-  _globals['_SN13SERVICE']._serialized_start=754
-  _globals['_SN13SERVICE']._serialized_end=1013
+  _globals['_ONDEMANDDATAREQUEST']._serialized_end=677
+  _globals['_ONDEMANDDATARESPONSE']._serialized_start=679
+  _globals['_ONDEMANDDATARESPONSE']._serialized_end=795
+  _globals['_SN13SERVICE']._serialized_start=798
+  _globals['_SN13SERVICE']._serialized_end=1057
 # @@protoc_insertion_point(module_scope)

--- a/src/macrocosmos/generated/sn13/v1/sn13_validator_pb2.pyi
+++ b/src/macrocosmos/generated/sn13/v1/sn13_validator_pb2.pyi
@@ -49,20 +49,22 @@ class ValidateRedditTopicResponse(_message.Message):
     def __init__(self, platform: _Optional[str] = ..., topic: _Optional[str] = ..., exists: bool = ..., over18: bool = ..., quarantine: bool = ...) -> None: ...
 
 class OnDemandDataRequest(_message.Message):
-    __slots__ = ("source", "usernames", "keywords", "start_date", "end_date", "limit")
+    __slots__ = ("source", "usernames", "keywords", "start_date", "end_date", "limit", "keyword_mode")
     SOURCE_FIELD_NUMBER: _ClassVar[int]
     USERNAMES_FIELD_NUMBER: _ClassVar[int]
     KEYWORDS_FIELD_NUMBER: _ClassVar[int]
     START_DATE_FIELD_NUMBER: _ClassVar[int]
     END_DATE_FIELD_NUMBER: _ClassVar[int]
     LIMIT_FIELD_NUMBER: _ClassVar[int]
+    KEYWORD_MODE_FIELD_NUMBER: _ClassVar[int]
     source: str
     usernames: _containers.RepeatedScalarFieldContainer[str]
     keywords: _containers.RepeatedScalarFieldContainer[str]
     start_date: str
     end_date: str
     limit: int
-    def __init__(self, source: _Optional[str] = ..., usernames: _Optional[_Iterable[str]] = ..., keywords: _Optional[_Iterable[str]] = ..., start_date: _Optional[str] = ..., end_date: _Optional[str] = ..., limit: _Optional[int] = ...) -> None: ...
+    keyword_mode: str
+    def __init__(self, source: _Optional[str] = ..., usernames: _Optional[_Iterable[str]] = ..., keywords: _Optional[_Iterable[str]] = ..., start_date: _Optional[str] = ..., end_date: _Optional[str] = ..., limit: _Optional[int] = ..., keyword_mode: _Optional[str] = ...) -> None: ...
 
 class OnDemandDataResponse(_message.Message):
     __slots__ = ("status", "data", "meta")

--- a/src/macrocosmos/resources/sn13.py
+++ b/src/macrocosmos/resources/sn13.py
@@ -29,7 +29,8 @@ class AsyncSn13:
         keywords: List[str],
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
-        limit: int = 5,
+        limit: int = 100,
+        keyword_mode: Optional[str] = None,
     ) -> sn13_validator_pb2.OnDemandDataResponse:
         """
         Retrieves on-demand data from the SN13 API service asynchronously, based on the provided parameters.
@@ -41,6 +42,8 @@ class AsyncSn13:
             start_date (str): Date from which we want to start fetching data. ISO 8601 formatted date string (e.g. "2024-01-01T00:00:00Z")
             end_date (str): Date up to which we want to fetch data. ISO 8601 formatted date string (e.g. "2024-01-01T00:00:00Z")
             limit (int): Maximum number of results to return
+            keyword_mode (str): Defines how keywords should be used in selecting response posts (optional): 
+                "all" (posts must include all keywords) or "any" (posts can include any combination of keywords)
 
         Returns:
             dict:
@@ -55,6 +58,7 @@ class AsyncSn13:
             start_date=start_date,
             end_date=end_date,
             limit=limit,
+            keyword_mode=keyword_mode,
         )
 
         return await self._make_request("OnDemandData", request)
@@ -129,7 +133,8 @@ class SyncSn13:
         keywords: List[str],
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
-        limit: int = 5,
+        limit: int = 100,
+        keyword_mode: Optional[str] = None,
     ) -> sn13_validator_pb2.OnDemandDataResponse:
         """
         Retrieves on-demand data from the SN13 API service synchronously, based on the provided parameters.
@@ -141,7 +146,8 @@ class SyncSn13:
             start_date (str): Date from which we want to start fetching data. ISO 8601 formatted date string (e.g. "2024-01-01T00:00:00Z")
             end_date (str): Date up to which we want to fetch data. ISO 8601 formatted date string (e.g. "2024-01-01T00:00:00Z")
             limit (int): Maximum number of results to return
-
+            keyword_mode (str): Defines how keywords should be used in selecting response posts (optional): 
+                "all" (posts must include all keywords) or "any" (posts can include any combination of keywords)
         Returns:
             dict:
                 - status (str): The request status
@@ -156,5 +162,6 @@ class SyncSn13:
                 start_date=start_date,
                 end_date=end_date,
                 limit=limit,
+                keyword_mode=keyword_mode,
             )
         )

--- a/src/macrocosmos/resources/sn13.py
+++ b/src/macrocosmos/resources/sn13.py
@@ -42,7 +42,7 @@ class AsyncSn13:
             start_date (str): Date from which we want to start fetching data. ISO 8601 formatted date string (e.g. "2024-01-01T00:00:00Z")
             end_date (str): Date up to which we want to fetch data. ISO 8601 formatted date string (e.g. "2024-01-01T00:00:00Z")
             limit (int): Maximum number of results to return
-            keyword_mode (str): Defines how keywords should be used in selecting response posts (optional): 
+            keyword_mode (str): Defines how keywords should be used in selecting response posts (optional):
                 "all" (posts must include all keywords) or "any" (posts can include any combination of keywords)
 
         Returns:
@@ -146,7 +146,7 @@ class SyncSn13:
             start_date (str): Date from which we want to start fetching data. ISO 8601 formatted date string (e.g. "2024-01-01T00:00:00Z")
             end_date (str): Date up to which we want to fetch data. ISO 8601 formatted date string (e.g. "2024-01-01T00:00:00Z")
             limit (int): Maximum number of results to return
-            keyword_mode (str): Defines how keywords should be used in selecting response posts (optional): 
+            keyword_mode (str): Defines how keywords should be used in selecting response posts (optional):
                 "all" (posts must include all keywords) or "any" (posts can include any combination of keywords)
         Returns:
             dict:

--- a/uv.lock
+++ b/uv.lock
@@ -511,7 +511,7 @@ wheels = [
 
 [[package]]
 name = "macrocosmos"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio", version = "1.70.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
### Description

This PR adds an optional request parameter, `keyword_mode`, to the `OnDemandData` service. This will allow users to select two post-filtering modes:

- "any": Returns posts that contain any combination of the listed keywords.
- "all": Returns posts that contain all of the keywords (default, if field omitted).

#### Changes
- `README.md` and examples `sn13_on_demand_data.py`, `sn13_on_demand_data_async.py` updated to use `keyword_mode` parameter.
- Version of SDK has been updated to `v1.1.4`.
- Update default `limit` in `sn13.py` to `100`.